### PR TITLE
Fix requeue lua script crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 argparse==1.2.1
-msgpack-python==0.4.1
-redis==2.9.1
+msgpack-python==0.5.6
+redis==3.2.1
 wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='SharQ',
-    version='0.4.0',
+    version='0.5.0',
     url='https://github.com/plivo/sharq',
     author='Plivo Team',
     author_email='hello@plivo.com',

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     description='An API queueing system built at Plivo.',
     long_description=open('README.md').read(),
     install_requires=[
-        'redis==2.10.1',
-        'msgpack-python==0.4.2'
+        'redis>=2.10.1',
+        'msgpack-python>=0.4.2'
     ],
     classifiers = [
         'Development Status :: 5 - Production/Stable',

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -198,7 +198,7 @@ class SharQ(object):
 
         dequeue_response = self._lua_dequeue(keys=keys, args=args)
 
-        if len(dequeue_response) < 4:
+        if len(dequeue_response) < 4 or None in dequeue_response:
             response = {
                 'status': 'failure'
             }

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -452,15 +452,15 @@ class SharQ(object):
             raise BadArgumentException('`queue_type` has an invalid value.')
 
         response = {
-            'status': 'Failure',
+            'status': 'failure',
             'message': 'No queued calls found'
             }
         # remove from the primary sorted set
         primary_set = '{}:{}'.format(self._key_prefix, queue_type)
         queued_status = self._r.zrem(primary_set, queue_id)
         if queued_status:
-            response.update({'status': 'Success', 
-                    'message': 'Successfully removed all queued calls'})
+            response.update({'status': 'success',
+                    'message': 'successfully removed all queued calls'})
         # do a full cleanup of reources
         # although this is not necessary as we don't remove resources 
         # while dequeue operation
@@ -482,8 +482,8 @@ class SharQ(object):
             # clear job_queue_list
             pipe.delete(job_queue_list)
             pipe.execute()
-            response.update({'status': 'Success', 
-                    'message': 'Successfully removed all queued calls and purged related resources'})
+            response.update({'status': 'success',
+                    'message': 'successfully removed all queued calls and purged related resources'})
         else:
             # always delete the job queue list
             self._r.delete(job_queue_list)

--- a/sharq/scripts/lua/requeue.lua
+++ b/sharq/scripts/lua/requeue.lua
@@ -18,7 +18,7 @@ for _, job in pairs(requeue_job_list) do
    local queue_id, job_id = job:match("([^,]+):([^,]+)")
    -- check if the job has any pending requeues.
    local requeues_remaining = redis.call('HGET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':requeues_remaining', job_id)
-   if tonumber(requeues_remaining) > -1 then
+   if requeues_remaining and tonumber(requeues_remaining) > -1 then
       -- finite requeues_remaining. decrement by one and check.
       requeues_remaining = requeues_remaining - 1
       -- update the new requeues_remaining value.
@@ -36,16 +36,13 @@ for _, job in pairs(requeue_job_list) do
        redis.call('LPUSH', job_queue_key, job_id)
        -- check if this is the only job in the job queue
        if redis.call('LLEN', job_queue_key) == 1 then
-	  -- check if the time keeper exists
-	  local next_ready_time = 0
-	  if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':time') == 1 then
-	     local last_dequeue_time = redis.call('GET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':time')
-	     local interval = redis.call('HGET', KEYS[1] .. ':interval', KEYS[2] .. ':' .. queue_id)
-	     -- compute next ready time
+	  -- time keeper may not exist, so initialize next ready time to now.
+	  local next_ready_time = ARGV[1]
+	  local last_dequeue_time = tonumber(redis.call('GET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':time'))
+	  local interval = tonumber(redis.call('HGET', KEYS[1] .. ':interval', KEYS[2] .. ':' .. queue_id))
+	  if last_dequeue_time and interval then
+	     -- time keeper exists, compute next ready time
 	     next_ready_time = last_dequeue_time + interval
-	  else
-	     -- time keeper does not exist. next ready time is now.
-	     next_ready_time = ARGV[1]
 	  end
 	  -- insert this queue into the ready sorted set.
 	  redis.call('ZADD', KEYS[1] .. ':' .. KEYS[2], next_ready_time, queue_id)

--- a/sharq/sharq.conf
+++ b/sharq/sharq.conf
@@ -1,7 +1,7 @@
 [sharq]
-job_expire_interval       : 1000 ; in milliseconds
-job_requeue_interval      : 1000 ; in milliseconds
-default_job_requeue_limit : -1 ; retries infinitely
+job_expire_interval       : 120000 ; in milliseconds
+job_requeue_interval      : 5000 ; in milliseconds
+default_job_requeue_limit : 0 ; value of -1 retries infinitely
 
 [redis]
 db                        : 0

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -309,7 +309,7 @@ class SharQTest(unittest.TestCase):
     def test_enqueue_cannot_serialize_payload(self):
         self.assertRaisesRegexp(
             BadArgumentException,
-            r'can not serialize.',
+            r'can\'t serialize',
             self.queue.enqueue,
             payload=self.invalid_payload,
             interval=self.valid_interval,


### PR DESCRIPTION
Unlike user driven operation such as enqueue, dequeue and finish, requeue operation is a server side maintenance operation that has to be periodically invoked. The goal of requeue operation is to add expired jobs back to the queue if the job hasn't exceeded the number of times it can be requeued.

The requeue Lua script fetches multiple keys which may no longer exist, perhaps due to a race somewhere. This has been fixed at 2 known places where exceptions have been observed as follows:

```
user_script:45: attempt to perform arithmetic on local 'interval' (a boolean value)
user_script:21: attempt to compare number with nil
```

P.S: This PR also fixes existing unit tests. Running `make test` will now pass.