### PR TITLE
Changed to support redis cluster with backward compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+MAJOR RELEASE v0.5.0
+	- Adds support for Redis Cluster mode in TCP socket mode only
+
 MAJOR RELEASE v0.3.0
 	- Adds the requeue limit feature which bounds
 	  the job retries in SHARQ.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ argparse==1.2.1
 msgpack-python==0.4.1
 redis==2.9.1
 wsgiref==0.1.2
+rediscluster=0.5.3

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='SharQ',
-    version='0.4.0',
+    version='0.5.0',
     url='https://github.com/plivo/sharq',
     author='Plivo Team',
     author_email='hello@plivo.com',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     install_requires=[
         'redis==2.10.1',
         'msgpack-python==0.4.2'
+        'rediscluster=0.5.3'
     ],
     classifiers = [
         'Development Status :: 5 - Production/Stable',

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -5,6 +5,7 @@ import sys
 import signal
 import ConfigParser
 import redis
+from rediscluster import StrictRedisCluster
 from sharq.utils import (is_valid_identifier, is_valid_interval,
                          is_valid_requeue_limit, generate_epoch,
                          serialize_payload, deserialize_payload)
@@ -52,12 +53,15 @@ class SharQ(object):
                 unix_socket_path=self._config.get('redis', 'unix_socket_path')
             )
         elif redis_connection_type == 'tcp_sock':
-            self._r = redis.StrictRedis(
-                db=db,
-                host=self._config.get('redis', 'host'),
-                port=self._config.get('redis', 'port')
-            )
-
+            if self._config.get("clustered_mode"):
+                startup_nodes = [{"host":self._config.get('redis', 'host'), "port":self._config.get('redis', 'port')}]
+                self._r = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True,skip_full_coverage_check=True)
+            else:
+                self._r = redis.StrictRedis(
+                    db=db,
+                    host=self._config.get('redis', 'host'),
+                    port=self._config.get('redis', 'port')
+                )
         self._load_lua_scripts()
 
     def _load_config(self):

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -55,7 +55,7 @@ class SharQ(object):
         elif redis_connection_type == 'tcp_sock':
             if self._config.getboolean('redis', 'clustered', fallback=False):
                 startup_nodes = [{"host":self._config.get('redis', 'host'), "port":self._config.get('redis', 'port')}]
-                self._r = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True,skip_full_coverage_check=True)
+                self._r = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True, skip_full_coverage_check=True)
             else:
                 self._r = redis.StrictRedis(
                     db=db,

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -53,7 +53,7 @@ class SharQ(object):
                 unix_socket_path=self._config.get('redis', 'unix_socket_path')
             )
         elif redis_connection_type == 'tcp_sock':
-            if self._config.get("clustered_mode"):
+            if self._config.getboolean('redis', 'clustered'):
                 startup_nodes = [{"host":self._config.get('redis', 'host'), "port":self._config.get('redis', 'port')}]
                 self._r = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True,skip_full_coverage_check=True)
             else:

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -53,7 +53,7 @@ class SharQ(object):
                 unix_socket_path=self._config.get('redis', 'unix_socket_path')
             )
         elif redis_connection_type == 'tcp_sock':
-            if self._config.getboolean('redis', 'clustered'):
+            if self._config.getboolean('redis', 'clustered', fallback=False):
                 startup_nodes = [{"host":self._config.get('redis', 'host'), "port":self._config.get('redis', 'port')}]
                 self._r = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True,skip_full_coverage_check=True)
             else:

--- a/sharq/sharq.conf
+++ b/sharq/sharq.conf
@@ -12,3 +12,4 @@ unix_socket_path          : /tmp/redis.sock
 ;; tcp connection settings
 port                      : 6379
 host                      : 127.0.0.1
+clustered_mode            : false  

--- a/sharq/sharq.conf
+++ b/sharq/sharq.conf
@@ -12,4 +12,4 @@ unix_socket_path          : /tmp/redis.sock
 ;; tcp connection settings
 port                      : 6379
 host                      : 127.0.0.1
-clustered_mode            : false  
+clustered                 : false  


### PR DESCRIPTION
This change is for sharq library to be able to connect with Redis cluster as well. If clustered config is not defined then the library will use the non clustered mode 