### PR TITLE
Handle known races caused by requeue script

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+MINOR RELEASE v1.1.0
+	- Handle known races in requeue logic.
+
 MAJOR RELEASE v1.0.0
 	- Upgrade python version to 3.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 argparse==1.2.1
 msgpack==0.5.6
 wsgiref==0.1.2
-redis-py-cluster==2.0.0
+redis-py-cluster==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='SharQ',
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/plivo/sharq',
     author='Plivo Team',
     author_email='voice-team@plivo.com',

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -315,6 +315,9 @@ class SharQ(object):
             '%s:active:queue_type' % self._key_prefix)
         for queue_type in active_queue_type_list:
             # requeue all expired jobs in all queue types.
+
+            queue_type = queue_type.decode('utf-8')
+
             keys = [
                 self._key_prefix,
                 queue_type

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -217,6 +217,13 @@ class SharQ(object):
             return response
 
         queue_id, job_id, payload, requeues_remaining = dequeue_response
+
+        if payload is None:
+            response = {
+                'status': 'failure'
+            }
+            return response
+
         payload = deserialize_payload(payload)
 
         response = {

--- a/sharq/queue.py
+++ b/sharq/queue.py
@@ -75,6 +75,9 @@ class SharQ(object):
         self._config = configparser.SafeConfigParser()
         self._config.read(self.config_path)
 
+    def redis_client(self):
+        return self._r
+
     def reload_config(self, config_path=None):
         """Reload the configuration from the new config file if provided
         else reload the current config file.

--- a/sharq/scripts/lua/dequeue.lua
+++ b/sharq/scripts/lua/dequeue.lua
@@ -10,63 +10,70 @@
 --     { queue_id, job_id, payload, requeues_remaining }
 
 
-local ready_queue_id_list = redis.call('ZRANGEBYSCORE', KEYS[1] .. ':' .. KEYS[2], 0, ARGV[1])
+local prefix = KEYS[1]
+local queue_type = KEYS[2]
+
+local current_timestamp = ARGV[1]
+local job_expiry_interval = ARGV[2]
+
+
+local ready_queue_id_list = redis.call('ZRANGEBYSCORE', prefix .. ':' .. queue_type, 0, current_timestamp)
 if next(ready_queue_id_list) ~= nil then
    -- there is a queue ready to be dequeued.
    local ready_queue_id = ready_queue_id_list[1]
    -- dequeue a job from the job queue.
-   local job_id = redis.call('LPOP', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id)
+   local job_id = redis.call('LPOP', prefix .. ':' .. queue_type .. ':' .. ready_queue_id)
    -- get the payload for this job
-   local payload = redis.call('HGET', KEYS[1] .. ':payload', KEYS[2] .. ':' .. ready_queue_id .. ':' .. job_id)
+   local payload = redis.call('HGET', prefix .. ':payload', queue_type .. ':' .. ready_queue_id .. ':' .. job_id)
    -- update the time keeper with the current dequeue time.
-   local interval = redis.call('HGET', KEYS[1] .. ':interval', KEYS[2] .. ':' .. ready_queue_id)
-   redis.call('PSETEX', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id .. ':time', ARGV[2], ARGV[1])
+   local interval = redis.call('HGET', prefix .. ':interval', queue_type .. ':' .. ready_queue_id)
+   redis.call('PSETEX', prefix .. ':' .. queue_type .. ':' .. ready_queue_id .. ':time', job_expiry_interval, current_timestamp)
    -- check if there are any more jobs of this queue in the job queue.
-   if redis.call('LLEN', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id) == 0 then
+   if redis.call('LLEN', prefix .. ':' .. queue_type .. ':' .. ready_queue_id) == 0 then
       -- there are no more jobs of this queue. remove this queue from the ready sorted set.
-      redis.call('ZREM', KEYS[1] .. ':' .. KEYS[2], ready_queue_id)
+      redis.call('ZREM', prefix .. ':' .. queue_type, ready_queue_id)
       -- now check if the ready sorted set is empty.
-      if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2]) ~= 1 then
+      if redis.call('EXISTS', prefix .. ':' .. queue_type) ~= 1 then
 	 -- the ready sorted set is empty. remove this 'queue_type' from
 	 -- the metris ready queue type set
-	 redis.call('SREM', KEYS[1] .. ':ready:queue_type', KEYS[2])
+	 redis.call('SREM', prefix .. ':ready:queue_type', queue_type)
       end
    else
       -- there are more jobs in the queue. update the next
       -- dequeue time for this queue in the ready sorted set.
-      local next_dequeue_time = ARGV[1] + interval
-      redis.call('ZADD', KEYS[1] .. ':' .. KEYS[2], next_dequeue_time, ready_queue_id)
+      local next_dequeue_time = current_timestamp + interval
+      redis.call('ZADD', prefix .. ':' .. queue_type, next_dequeue_time, ready_queue_id)
    end
-   local job_expiry_time = ARGV[1] + ARGV[2]
+   local job_expiry_time = current_timestamp + job_expiry_interval
    -- finally, add the job_id and queue_id that was dequeued into the active sorted set.
-   redis.call('ZADD', KEYS[1] .. ':' .. KEYS[2] .. ':active', job_expiry_time, ready_queue_id .. ':' .. job_id)
+   redis.call('ZADD', prefix .. ':' .. queue_type .. ':active', job_expiry_time, ready_queue_id .. ':' .. job_id)
    -- add the queue_type to metrics active queue type set.
-   redis.call('SADD', KEYS[1] .. ':active:queue_type', KEYS[2])
+   redis.call('SADD', prefix .. ':active:queue_type', queue_type)
 
    -- get the requeues_remaining for this job
-   local requeues_remaining = redis.call('HGET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id .. ':requeues_remaining', job_id)
+   local requeues_remaining = redis.call('HGET', prefix .. ':' .. queue_type .. ':' .. ready_queue_id .. ':requeues_remaining', job_id)
 
    -- update the metrics counters
    -- update global counter.
-   local timestamp_minute = math.floor(ARGV[1]/60000) * 60000 -- get the epoch for the minute
+   local timestamp_minute = math.floor(current_timestamp/60000) * 60000 -- get the epoch for the minute
    local expiry_time = math.floor((timestamp_minute + 600000) / 1000) -- store the data for 10 minutes.
-   if redis.call('EXISTS', KEYS[1] .. ':dequeue_counter:' .. timestamp_minute) ~= 1 then
+   if redis.call('EXISTS', prefix .. ':dequeue_counter:' .. timestamp_minute) ~= 1 then
       -- counter does not exists. set the initial value and expiry.
-      redis.call('SET', KEYS[1] .. ':dequeue_counter:' .. timestamp_minute, 1)
-      redis.call('EXPIREAT', KEYS[1] .. ':dequeue_counter:' .. timestamp_minute, expiry_time)
+      redis.call('SET', prefix .. ':dequeue_counter:' .. timestamp_minute, 1)
+      redis.call('EXPIREAT', prefix .. ':dequeue_counter:' .. timestamp_minute, expiry_time)
    else
       -- counter already exists. just increment the value.
-      redis.call('INCR', KEYS[1] .. ':dequeue_counter:' .. timestamp_minute)
+      redis.call('INCR', prefix .. ':dequeue_counter:' .. timestamp_minute)
    end
 
    -- update the current queue counter.
-   if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute) ~= 1 then
+   if redis.call('EXISTS', prefix .. ':' .. queue_type .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute) ~= 1 then
       -- counter does not exists. set the initial value and expiry.
-      redis.call('SET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute, 1)
-      redis.call('EXPIREAT', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute, expiry_time)
+      redis.call('SET', prefix .. ':' .. queue_type .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute, 1)
+      redis.call('EXPIREAT', prefix .. ':' .. queue_type .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute, expiry_time)
    else
       -- counter already exists. just increment the value.
-      redis.call('INCR', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute)
+      redis.call('INCR', prefix .. ':' .. queue_type .. ':' .. ready_queue_id .. ':dequeue_counter:' .. timestamp_minute)
    end
 
    return { ready_queue_id, job_id, payload, requeues_remaining }

--- a/sharq/scripts/lua/enqueue.lua
+++ b/sharq/scripts/lua/enqueue.lua
@@ -13,55 +13,63 @@
 -- output:
 --     nil
 
+local prefix = KEYS[1]
+local queue_type = KEYS[2]
+
+local current_timestamp = ARGV[1]
+local queue_id = ARGV[2]
+local job_id = ARGV[3]
+local payload = ARGV[4]
+local interval = ARGV[5]
+local requeue_limit = ARGV[6]
 
 -- push the job id into the job queue.
-redis.call('RPUSH', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2], ARGV[3])
+redis.call('RPUSH', prefix .. ':' .. queue_type .. ':' .. queue_id, job_id)
 
 -- update the payload map.
-redis.call('HSET', KEYS[1] .. ':payload', KEYS[2] .. ':' .. ARGV[2] .. ':' .. ARGV[3], ARGV[4])
+redis.call('HSET', prefix .. ':payload', queue_type .. ':' .. queue_id .. ':' .. job_id, payload)
 
 -- update the interval map.
-redis.call('HSET', KEYS[1] .. ':interval', KEYS[2] .. ':' .. ARGV[2], ARGV[5])
+redis.call('HSET', prefix .. ':interval', queue_type .. ':' .. queue_id, interval)
 
 -- update the requeue limit map.
-redis.call('HSET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2] .. ':requeues_remaining', ARGV[3], ARGV[6])
+redis.call('HSET', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':requeues_remaining', job_id, requeue_limit)
 
 -- check if the queue of this job is already present in the ready sorted set.
-if not redis.call('ZRANK', KEYS[1] .. ':' .. KEYS[2], ARGV[2]) then
+if not redis.call('ZRANK', prefix .. ':' .. queue_type, queue_id) then
    -- the ready sorted set is empty, update it and add it to metrics ready queue type set.
-   redis.call('SADD', KEYS[1] .. ':ready:queue_type', KEYS[2])
-   if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2] .. ':time') ~= 1 then
+   redis.call('SADD', prefix .. ':ready:queue_type', queue_type)
+   if redis.call('EXISTS', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':time') ~= 1 then
       -- time keeper does not exist
       -- update the ready sorted set with current time as ready time.
-      redis.call('ZADD', KEYS[1] .. ':' .. KEYS[2], ARGV[1], ARGV[2])
+      redis.call('ZADD', prefix .. ':' .. queue_type, current_timestamp, queue_id)
    else
       -- time keeper exists
-      local interval = ARGV[5]
-      local last_dequeue_time = redis.call('GET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2] .. ':time')
+      local last_dequeue_time = redis.call('GET', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':time')
       local ready_time = interval + last_dequeue_time
-      redis.call('ZADD', KEYS[1] .. ':' .. KEYS[2], ready_time, ARGV[2])
+      redis.call('ZADD', prefix .. ':' .. queue_type, ready_time, queue_id)
    end
 end
 
 -- update the metrics counters
 -- update global counter.
-local timestamp_minute = math.floor(ARGV[1]/60000) * 60000 -- get the epoch for the minute
+local timestamp_minute = math.floor(current_timestamp/60000) * 60000 -- get the epoch for the minute
 local expiry_time = math.floor((timestamp_minute + 600000) / 1000) -- store the data for 10 minutes.
-if redis.call('EXISTS', KEYS[1] .. ':enqueue_counter:' .. timestamp_minute) ~= 1 then
+if redis.call('EXISTS', prefix .. ':enqueue_counter:' .. timestamp_minute) ~= 1 then
    -- counter does not exists. set the initial value and expiry.
-   redis.call('SET', KEYS[1] .. ':enqueue_counter:' .. timestamp_minute, 1)
-   redis.call('EXPIREAT', KEYS[1] .. ':enqueue_counter:' .. timestamp_minute, expiry_time)
+   redis.call('SET', prefix .. ':enqueue_counter:' .. timestamp_minute, 1)
+   redis.call('EXPIREAT', prefix .. ':enqueue_counter:' .. timestamp_minute, expiry_time)
 else
    -- counter already exists. just increment the value.
-   redis.call('INCR', KEYS[1] .. ':enqueue_counter:' .. timestamp_minute)
+   redis.call('INCR', prefix .. ':enqueue_counter:' .. timestamp_minute)
 end
 
 -- update the current queue counter.
-if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2] .. ':enqueue_counter:' .. timestamp_minute) ~= 1 then
+if redis.call('EXISTS', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':enqueue_counter:' .. timestamp_minute) ~= 1 then
    -- counter does not exists. set the initial value and expiry.
-   redis.call('SET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2] .. ':enqueue_counter:' .. timestamp_minute, 1)
-   redis.call('EXPIREAT', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2] .. ':enqueue_counter:' .. timestamp_minute, expiry_time)
+   redis.call('SET', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':enqueue_counter:' .. timestamp_minute, 1)
+   redis.call('EXPIREAT', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':enqueue_counter:' .. timestamp_minute, expiry_time)
 else
    -- counter already exists. just increment the value.
-   redis.call('INCR', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[2] .. ':enqueue_counter:' .. timestamp_minute)
+   redis.call('INCR', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':enqueue_counter:' .. timestamp_minute)
 end

--- a/sharq/scripts/lua/finish.lua
+++ b/sharq/scripts/lua/finish.lua
@@ -9,9 +9,14 @@
 -- output:
 --     nil
 
+local prefix = KEYS[1]
+local queue_type = KEYS[2]
+local queue_id = ARGV[1]
+local job_id = ARGV[2]
+
 
 -- remove the job from active sorted set.
-local response = redis.call('ZREM', KEYS[1] .. ':' .. KEYS[2] .. ':active', ARGV[1] .. ':' .. ARGV[2])
+local response = redis.call('ZREM', prefix .. ':' .. queue_type .. ':active', queue_id .. ':' .. job_id)
 if response ~= 1 then
    -- the job was not found in the active sorted set. Non existent job or
    -- the job is expired and was requeued back.
@@ -19,19 +24,19 @@ if response ~= 1 then
 end
 
 -- check if the just-removed job was the last job in the active sorted set.
-if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':active') ~= 1 then
+if redis.call('EXISTS', prefix .. ':' .. queue_type .. ':active') ~= 1 then
    -- yes. this was the last job. remove this queue_type
    -- from the metrics active queue type set.
-   redis.call('SREM', KEYS[1] .. ':active:queue_type', KEYS[2])
+   redis.call('SREM', prefix .. ':active:queue_type', queue_type)
 end
 -- delete the payload related to this job from the payload map.
-redis.call('HDEL', KEYS[1] .. ':payload', KEYS[2] .. ':' .. ARGV[1] .. ':' .. ARGV[2])
-if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[1]) ~= 1 then
+redis.call('HDEL', prefix .. ':payload', queue_type .. ':' .. queue_id .. ':' .. job_id)
+if redis.call('EXISTS', prefix .. ':' .. queue_type .. ':' .. queue_id) ~= 1 then
    -- there are no more jobs in this queue. we can safely delete the interval.
-   redis.call('HDEL', KEYS[1] .. ':interval', KEYS[2] .. ':' .. ARGV[1])
+   redis.call('HDEL', prefix .. ':interval', queue_type .. ':' .. queue_id)
 end
 
 -- delete the requeues_remaining entry for this job.
-redis.call('HDEL', KEYS[1] .. ':' .. KEYS[2] .. ':' .. ARGV[1] .. ':requeues_remaining', ARGV[2])
+redis.call('HDEL', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':requeues_remaining', job_id)
 
 return 1

--- a/sharq/scripts/lua/requeue.lua
+++ b/sharq/scripts/lua/requeue.lua
@@ -9,20 +9,24 @@
 -- output:
 --     {} or job_discard_list
 
+local prefix = KEYS[1]
+local queue_type = KEYS[2]
+local current_timestamp = ARGV[1]
+
 -- check if any of the jobs need to be retried
-local requeue_job_list = redis.call('ZRANGEBYSCORE', KEYS[1] .. ':' .. KEYS[2] .. ':active', 0, ARGV[1])
+local requeue_job_list = redis.call('ZRANGEBYSCORE', prefix .. ':' .. queue_type .. ':active', 0, current_timestamp)
 local job_discard_list = {}
 -- iterate over each job and requeue it.
 for _, job in pairs(requeue_job_list) do
    local requeue = true
    local queue_id, job_id = job:match("([^,]+):([^,]+)")
    -- check if the job has any pending requeues.
-   local requeues_remaining = redis.call('HGET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':requeues_remaining', job_id)
+   local requeues_remaining = redis.call('HGET', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':requeues_remaining', job_id)
    if tonumber(requeues_remaining) > -1 then
       -- finite requeues_remaining. decrement by one and check.
       requeues_remaining = requeues_remaining - 1
       -- update the new requeues_remaining value.
-      redis.call('HSET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':requeues_remaining', job_id, requeues_remaining)
+      redis.call('HSET', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':requeues_remaining', job_id, requeues_remaining)
       if requeues_remaining == -1 then
          -- discard this job
 	 table.insert(job_discard_list, job)
@@ -32,31 +36,31 @@ for _, job in pairs(requeue_job_list) do
    end
    if requeue == true then
        -- enqueue the job at the front of the job queue
-       local job_queue_key = KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id
+       local job_queue_key = prefix .. ':' .. queue_type .. ':' .. queue_id
        redis.call('LPUSH', job_queue_key, job_id)
        -- check if this is the only job in the job queue
        if redis.call('LLEN', job_queue_key) == 1 then
 	  -- check if the time keeper exists
 	  local next_ready_time = 0
-	  if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':time') == 1 then
-	     local last_dequeue_time = redis.call('GET', KEYS[1] .. ':' .. KEYS[2] .. ':' .. queue_id .. ':time')
-	     local interval = redis.call('HGET', KEYS[1] .. ':interval', KEYS[2] .. ':' .. queue_id)
+	  if redis.call('EXISTS', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':time') == 1 then
+	     local last_dequeue_time = redis.call('GET', prefix .. ':' .. queue_type .. ':' .. queue_id .. ':time')
+	     local interval = redis.call('HGET', prefix .. ':interval', queue_type .. ':' .. queue_id)
 	     -- compute next ready time
 	     next_ready_time = last_dequeue_time + interval
 	  else
 	     -- time keeper does not exist. next ready time is now.
-	     next_ready_time = ARGV[1]
+	     next_ready_time = current_timestamp
 	  end
 	  -- insert this queue into the ready sorted set.
-	  redis.call('ZADD', KEYS[1] .. ':' .. KEYS[2], next_ready_time, queue_id)
-	  redis.call('SADD', KEYS[1] .. ':ready:queue_type', KEYS[2])
+	  redis.call('ZADD', prefix .. ':' .. queue_type, next_ready_time, queue_id)
+	  redis.call('SADD', prefix .. ':ready:queue_type', queue_type)
        end
        -- remove this queue_id & job_id from active sorted set.
-       redis.call('ZREM', KEYS[1] .. ':' .. KEYS[2] .. ':active', queue_id .. ':' .. job_id)
+       redis.call('ZREM', prefix .. ':' .. queue_type .. ':active', queue_id .. ':' .. job_id)
        -- check if the removed queue_id was the last item in this active set.
-       if redis.call('EXISTS', KEYS[1] .. ':' .. KEYS[2] .. ':active') ~= 1 then
+       if redis.call('EXISTS', prefix .. ':' .. queue_type .. ':active') ~= 1 then
 	  -- the active set does not exist. remove it from the metrics active queue type set.
-	  redis.call('SREM', KEYS[1] .. ':active:queue_type', KEYS[2])
+	  redis.call('SREM', prefix .. ':active:queue_type', queue_type)
        end
    end
 end

--- a/sharq/sharq.conf
+++ b/sharq/sharq.conf
@@ -1,7 +1,7 @@
 [sharq]
-job_expire_interval       = 1000
-job_requeue_interval      = 1000
-default_job_requeue_limit = -1
+job_expire_interval       : 120000 ; in milliseconds
+job_requeue_interval      : 5000 ; in milliseconds
+default_job_requeue_limit : 0 ; value of -1 retries infinitely
 
 [redis]
 db                        = 0

--- a/sharq/utils.py
+++ b/sharq/utils.py
@@ -65,6 +65,10 @@ def serialize_payload(payload):
 def deserialize_payload(payload):
     """Tries to deserialize the payload using msgpack.
     """
+    # Handle older SharQ payloads as well (before py3 migration)
+    if payload.startswith(b'"') and payload.endswith(b'"'):
+        return msgpack.unpackb(payload[1:-1], raw=False)
+
     return msgpack.unpackb(payload, raw=False)
 
 


### PR DESCRIPTION
The PR is divided into two parts for easier review. The first commit only renames variables for the whole codebase to become more readable.

The second part addresses two known races caused by running requeue scripts from multiple instances. The dequeue script assumes existence of some keys which may have been removed by the finish script. Testing should be able to uncover more such races if any.